### PR TITLE
Improper nesting in WebsterClay::Dominodes

### DIFF
--- a/libraries/dominodes.rb
+++ b/libraries/dominodes.rb
@@ -17,15 +17,16 @@ module WebsterClay
         d = Chef::DataBag.new
         d.name(data_bag)
         d.save
-        begin
-          Chef::DataBagItem.load(data_bag, lock_name)
-        rescue Net::HTTPServerException
-          Chef::Log.debug("Creating data bag item: #{lock_name}")
-          i = Chef::DataBagItem.new
-          i.data_bag(data_bag)
-          i.raw_data = {'id' => lock_name}
-          i.save
-        end
+      end
+      
+      begin
+        Chef::DataBagItem.load(data_bag, lock_name)
+      rescue Net::HTTPServerException
+        Chef::Log.debug("Creating data bag item: #{lock_name}")
+        i = Chef::DataBagItem.new
+        i.data_bag(data_bag)
+        i.raw_data = {'id' => lock_name}
+        i.save
       end
     end
 


### PR DESCRIPTION
I was testing out dominodes, realized I'd accidentally used the resource name used in the example from the readme, and so changed it to something more appropriate for my use case.  After doing this, my deploys broke.

I tracked it down to a bug in libraries/dominoes.rb.  The way that the data bag and data bag item creation sections were nested made it so that a data bag item would never be created if the 'dominodes' data bag already existed.

This pull request fixes that issue.
